### PR TITLE
Allow MariaDB grammar to be recognized

### DIFF
--- a/src/Enums/KpiInterval.php
+++ b/src/Enums/KpiInterval.php
@@ -10,6 +10,7 @@ use Elegantly\Kpi\SqlAdapters\MySqlAdapter;
 use Elegantly\Kpi\SqlAdapters\PostgreSqlAdapter;
 use Elegantly\Kpi\SqlAdapters\SqliteAdapter;
 use Error;
+use Illuminate\Database\Query\Grammars\MariaDbGrammar;
 use Illuminate\Database\Query\Grammars\MySqlGrammar;
 use Illuminate\Database\Query\Grammars\PostgresGrammar;
 use Illuminate\Database\Query\Grammars\SQLiteGrammar;
@@ -60,7 +61,7 @@ enum KpiInterval: string
     public function toSqlFormat(string $driver, string $column): string
     {
         return match ($driver) {
-            MySqlGrammar::class, 'mysql', 'mariadb' => MySqlAdapter::datetime($this, $column),
+            MySqlGrammar::class, 'mysql', MariaDbGrammar::class, 'mariadb', => MySqlAdapter::datetime($this, $column),
             SQLiteGrammar::class, 'sqlite' => SqliteAdapter::datetime($this, $column),
             PostgresGrammar::class, 'pgsql' => PostgreSqlAdapter::datetime($this, $column),
             default => throw new Error('Unsupported database driver.'),

--- a/src/Enums/KpiInterval.php
+++ b/src/Enums/KpiInterval.php
@@ -61,7 +61,7 @@ enum KpiInterval: string
     public function toSqlFormat(string $driver, string $column): string
     {
         return match ($driver) {
-            MySqlGrammar::class, 'mysql', MariaDbGrammar::class, 'mariadb', => MySqlAdapter::datetime($this, $column),
+            MySqlGrammar::class, 'mysql', MariaDbGrammar::class, 'mariadb' => MySqlAdapter::datetime($this, $column),
             SQLiteGrammar::class, 'sqlite' => SqliteAdapter::datetime($this, $column),
             PostgresGrammar::class, 'pgsql' => PostgreSqlAdapter::datetime($this, $column),
             default => throw new Error('Unsupported database driver.'),


### PR DESCRIPTION
Using MariaDB, you get Unsupported database driver. at vendor/elegantly/laravel-kpi/src/Enums/KpiInterval.php:66, because the driver isnt proprerly recognized