### PR TITLE
Allow the KPI model to point to a different database / schema table

### DIFF
--- a/config/kpi.php
+++ b/config/kpi.php
@@ -41,5 +41,5 @@ return [
     | (must implement Elegantly\Kpi\Contracts\KpiModelInterface)
     |
     */
-    'model' => null,
+    'model' => \Elegantly\Kpi\Models\Kpi::class,
 ];

--- a/config/kpi.php
+++ b/config/kpi.php
@@ -31,4 +31,15 @@ return [
     |
     */
     'definitions' => [],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Model
+    |--------------------------------------------------------------------------
+    |
+    | Here you can define a custom class to use for your Kpi model
+    | (must implement Elegantly\Kpi\Contracts\KpiModelInterface)
+    |
+    */
+    'model' => null,
 ];

--- a/database/factories/KpiFactory.php
+++ b/database/factories/KpiFactory.php
@@ -2,15 +2,30 @@
 
 namespace Elegantly\Kpi\Database\Factories;
 
+use Elegantly\Kpi\Contracts\KpiModelInterface;
 use Elegantly\Kpi\Models\Kpi;
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Collection;
 
 /**
  * @extends Factory<Kpi>
  */
 class KpiFactory extends Factory
 {
-    protected $model = Kpi::class;
+    public function __construct(
+        $count = null,
+        ?Collection $states = null,
+        ?Collection $has = null,
+        ?Collection $for = null,
+        ?Collection $afterMaking = null,
+        ?Collection $afterCreating = null,
+        $connection = null,
+        ?Collection $recycle = null,
+        bool $expandRelationships = true,
+    ) {
+        $this->model = app()->make(KpiModelInterface::class);
+        parent::__construct($count, $states, $has, $for, $afterMaking, $afterCreating, $connection, $recycle, $expandRelationships);
+    }
 
     public function definition()
     {

--- a/database/migrations/create_kpis_table.php.stub
+++ b/database/migrations/create_kpis_table.php.stub
@@ -41,6 +41,9 @@ return new class extends Migration
 
     public function down(): void
     {
-        Schema::dropIfExists('kpis');
+        $connection = app(KpiModelInterface::class)->getConnectionName();
+        $schema = app(KpiModelInterface::class)->getTable();
+
+        Schema::connection($connection)->dropIfExists($schema);
     }
 };

--- a/database/migrations/create_kpis_table.php.stub
+++ b/database/migrations/create_kpis_table.php.stub
@@ -8,7 +8,7 @@ return new class extends Migration
 {
     public function up()
     {
-        Schema::create('kpis', function (Blueprint $table) {
+        Schema::connection(config('kpi.connection', config('database.default')))->create(config('kpi.schema', 'kpis'), function (Blueprint $table) {
             $table->id();
 
             $table->string('name');

--- a/database/migrations/create_kpis_table.php.stub
+++ b/database/migrations/create_kpis_table.php.stub
@@ -1,5 +1,6 @@
 <?php
 
+use Elegantly\Kpi\Contracts\KpiModelInterface;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -8,7 +9,10 @@ return new class extends Migration
 {
     public function up()
     {
-        Schema::connection(config('kpi.connection', config('database.default')))->create(config('kpi.schema', 'kpis'), function (Blueprint $table) {
+        $connection = app(KpiModelInterface::class)->getConnectionName();
+        $schema = app(KpiModelInterface::class)->getTable();
+
+        Schema::connection($connection)->create($schema, function (Blueprint $table) {
             $table->id();
 
             $table->string('name');

--- a/src/Contracts/KpiModelInterface.php
+++ b/src/Contracts/KpiModelInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Elegantly\Kpi\Contracts;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * The inferface is only used in order to register the KPI Model app wide
+ */
+interface KpiModelInterface
+{
+
+}

--- a/src/KpiDefinition.php
+++ b/src/KpiDefinition.php
@@ -5,12 +5,14 @@ namespace Elegantly\Kpi;
 use Brick\Money\Money;
 use Carbon\CarbonInterface;
 use Carbon\CarbonPeriod;
+use Elegantly\Kpi\Contracts\KpiModelInterface;
 use Elegantly\Kpi\Enums\KpiAggregate;
 use Elegantly\Kpi\Enums\KpiInterval;
 use Elegantly\Kpi\Models\Kpi;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Collection as SupportCollection;
+use function app;
 
 /**
  * @template TValue of null|float|string|Money|array<array-key, mixed>
@@ -92,7 +94,7 @@ abstract class KpiDefinition
         /**
          * @var Kpi<TValue> $kpi
          */
-        $kpi = new Kpi;
+        $kpi = app(KpiModelInterface::class);
 
         $date ??= now();
 

--- a/src/KpiDefinition.php
+++ b/src/KpiDefinition.php
@@ -311,10 +311,12 @@ abstract class KpiDefinition
                 ->selectRaw('MAX(id) AS max_id')
                 ->groupByRaw($interval->toSqlFormat($grammar::class, 'date'));
 
+            $schema = app(KpiModelInterface::class)->getTable();
+
             $query->toBase()->joinSub(
                 query: $subquery,
                 as: 'subquery',
-                first: 'kpis.id',
+                first: "{$schema}.id",
                 operator: '=',
                 second: 'subquery.max_id'
             );

--- a/src/KpiDefinition.php
+++ b/src/KpiDefinition.php
@@ -156,8 +156,7 @@ abstract class KpiDefinition
          * @var Builder<Kpi<TValue>>
          */
 
-
-        $query = app('KpiModelInterface')::query()->where('name', static::getName());
+        $query = app(KpiModelInterface::class)::query()->where('name', static::getName());
 
         if ($start) {
             $query->where('date', '>=', $start);

--- a/src/KpiDefinition.php
+++ b/src/KpiDefinition.php
@@ -153,7 +153,9 @@ abstract class KpiDefinition
         /**
          * @var Builder<Kpi<TValue>>
          */
-        $query = Kpi::query()->where('name', static::getName());
+
+
+        $query = app('KpiModelInterface')::query()->where('name', static::getName());
 
         if ($start) {
             $query->where('date', '>=', $start);

--- a/src/KpiServiceProvider.php
+++ b/src/KpiServiceProvider.php
@@ -4,6 +4,7 @@ namespace Elegantly\Kpi;
 
 use Elegantly\Kpi\Commands\KpisSeedCommand;
 use Elegantly\Kpi\Commands\KpisSnapshotCommand;
+use Elegantly\Kpi\Contracts\KpiModelInterface;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 
@@ -22,5 +23,17 @@ class KpiServiceProvider extends PackageServiceProvider
             ->hasMigration('create_kpis_table')
             ->hasCommand(KpisSnapshotCommand::class)
             ->hasCommand(KpisSeedCommand::class);
+    }
+
+    public function register()
+    {
+        $customModelClass = config('kpi.model');
+        if ($customModelClass) {
+            $this->app->bind(KpiModelInterface::class, function ($app) use ($customModelClass) {
+                return $app->make($customModelClass);
+            });
+        }
+
+        parent::register();
     }
 }

--- a/src/KpiServiceProvider.php
+++ b/src/KpiServiceProvider.php
@@ -28,7 +28,7 @@ class KpiServiceProvider extends PackageServiceProvider
 
     public function register()
     {
-        $customModelClass = config('kpi.model', Kpi::class);
+        $customModelClass = config('kpi.model');
         if ($customModelClass) {
             $this->app->bind(KpiModelInterface::class, function ($app) use ($customModelClass) {
                 return $app->make($customModelClass);

--- a/src/KpiServiceProvider.php
+++ b/src/KpiServiceProvider.php
@@ -5,6 +5,7 @@ namespace Elegantly\Kpi;
 use Elegantly\Kpi\Commands\KpisSeedCommand;
 use Elegantly\Kpi\Commands\KpisSnapshotCommand;
 use Elegantly\Kpi\Contracts\KpiModelInterface;
+use Elegantly\Kpi\Models\Kpi;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 
@@ -27,7 +28,7 @@ class KpiServiceProvider extends PackageServiceProvider
 
     public function register()
     {
-        $customModelClass = config('kpi.model');
+        $customModelClass = config('kpi.model', Kpi::class);
         if ($customModelClass) {
             $this->app->bind(KpiModelInterface::class, function ($app) use ($customModelClass) {
                 return $app->make($customModelClass);

--- a/src/Models/Kpi.php
+++ b/src/Models/Kpi.php
@@ -4,6 +4,7 @@ namespace Elegantly\Kpi\Models;
 
 use Brick\Money\Money;
 use Carbon\CarbonInterface;
+use Elegantly\Kpi\Contracts\KpiModelInterface;
 use Elegantly\Kpi\Database\Factories\KpiFactory;
 use Elegantly\Money\MoneyCast;
 use Illuminate\Database\Eloquent\Casts\Attribute;
@@ -29,7 +30,7 @@ use Illuminate\Support\Arr;
  * @property CarbonInterface $created_at
  * @property CarbonInterface $updated_at
  */
-class Kpi extends Model
+class Kpi extends Model implements KpiModelInterface
 {
     /**
      * @use HasFactory<KpiFactory>


### PR DESCRIPTION
This PR allows me to use 2 different databases inside a single application. Use case is: i want to keep using my users / sessions table on the primary store, while collection / reading KPIs from a Postgres DB.

You can customize the model used in the `confg/kpi.php` file, extending the base Kpi model and adding the connection / schema in the new model:

``` Model.php
<?php

namespace App\Models;

use Elegantly\Kpi\Models\Kpi as KpiModel;

class Kpi extends KpiModel
{
    protected $table = 'your-kpis-table';
    protected $connection = 'your-connection';
}
```

``` config.php

        'model' => \App\Models\Kpi::class,

```